### PR TITLE
dont use deprecated action wpmu_new_blog, instead use wp_insert_site …

### DIFF
--- a/EED_Multisite.module.php
+++ b/EED_Multisite.module.php
@@ -1,4 +1,8 @@
 <?php
+
+use EventEspresso\core\exceptions\InvalidDataTypeException;
+use EventEspresso\core\exceptions\InvalidInterfaceException;
+
 if (! defined('EVENT_ESPRESSO_VERSION')) {
     exit('No direct script access allowed');
 }
@@ -415,12 +419,16 @@ class EED_Multisite extends EED_Module
     }
 
 
-
     /**
      * A blog was just created; let's immediately create its row in the blog meta table and
      * set its last updated time and status
      * (otherwise, if we wait, it's possible to get multiple simultenous requests
      * which will cause duplicate entries in the blog meta table)
+     * @param WP_Site $blog
+     * @throws EE_Error
+     * @throws InvalidArgumentException
+     * @throws InvalidDataTypeException
+     * @throws InvalidInterfaceException
      */
     public static function new_blog_created(WP_Site $blog)
     {

--- a/EED_Multisite.module.php
+++ b/EED_Multisite.module.php
@@ -99,7 +99,7 @@ class EED_Multisite extends EED_Module
                 10,
                 1
             );
-            add_action('wpmu_new_blog', array('EED_Multisite', 'new_blog_created'), 10, 1);
+            add_action('wp_insert_site', array('EED_Multisite', 'new_blog_created'), 10, 1);
             add_action('wp_loaded', array('EED_Multisite', 'update_last_requested'));
             add_filter('delete_blog', array('EED_Multisite', 'delete_ee_custom_tables_too'), 10, 2);
         }
@@ -422,14 +422,14 @@ class EED_Multisite extends EED_Module
      * (otherwise, if we wait, it's possible to get multiple simultenous requests
      * which will cause duplicate entries in the blog meta table)
      */
-    public static function new_blog_created($blog_id)
+    public static function new_blog_created(WP_Site $blog)
     {
         EEM_Blog::instance()->update_by_ID(
             array(
                 'BLG_last_requested' => current_time('mysql', true),
                 'STS_ID'             => EEM_Blog::status_up_to_date,
             ),
-            $blog_id
+            $blog->blog_id
         );
     }
 

--- a/EE_Multisite.class.php
+++ b/EE_Multisite.class.php
@@ -37,6 +37,8 @@ class EE_Multisite extends EE_Addon
             array(
                 'version'          => EE_MULTISITE_VERSION,
                 'min_core_version' => EE_MULTISITE_CORE_VERSION_REQUIRED,
+                // requires hook wp_insert_site introduced in WP 5.1
+                'min_wp_version' => '5.1',
                 'main_file_path'   => EE_MULTISITE_PLUGIN_FILE,
                 'admin_path'       => EE_MULTISITE_ADMIN,
                 'admin_callback'   => 'additional_admin_hooks',


### PR DESCRIPTION

<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Unit test failures, and brings the multisite up-to-date with WP 5.1 (which deprecated a hook we were using, although it wasn't entirely removed just yet).
Besides removing a warning, and increasing the minimum WP version, no changes should be noticed. 
Addresses https://github.com/eventespresso/eea-multisite/issues/1, also noticed on https://github.com/eventespresso/eventsmart.com-website/issues/562

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Create a new blog in WP. A new entry should be made in `wp_esp_blog_meta` for it.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
