### PR TITLE
Adjust the creator ID filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /.idea/
+vendor/
+composer.lock
+composer.json

--- a/EE_Multisite.class.php
+++ b/EE_Multisite.class.php
@@ -267,7 +267,7 @@ class EE_Multisite extends EE_Addon
             . "AND u2.meta_value LIKE %s ORDER BY user_id ASC LIMIT 1",
             $blogId,
             $wpdb->prefix . 'capabilities',
-            "%{$role_to_check}%"
+            '%"' . $role_to_check . '"%'
         );
         $user_id = $wpdb->get_var($query);
         $user_id = (int) apply_filters('FHEE__EE_Multisite__get_default_creator_id__user_id', $user_id);

--- a/EE_Multisite.class.php
+++ b/EE_Multisite.class.php
@@ -259,23 +259,18 @@ class EE_Multisite extends EE_Addon
         // find the earliest admin id for the current blog
         global $wpdb;
         $offset = 0;
-        $userIdToSave = null;
         $role_to_check = apply_filters('FHEE__EE_Multisite__get_default_creator_id__role_to_check', 'administrator');
         do {
             $query = $wpdb->prepare(
-                "SELECT user_id from {$wpdb->usermeta} WHERE meta_key='primary_blog' "
-                . "AND meta_value=%s ORDER BY user_id ASC LIMIT %d, 1",
+                "SELECT user_id from {$wpdb->usermeta} WHERE meta_key='primary_blog' AND meta_value=%s ORDER BY user_id ASC LIMIT %d, 1",
                 get_current_blog_id(),
                 $offset++
             );
             $user_id = $wpdb->get_var($query);
-            if ($user_id) {
-                $userIdToSave = $user_id;
-            }
         } while ($user_id && ! user_can($user_id, $role_to_check));
-        $userIdToPass = (int) apply_filters('FHEE__EE_Multisite__get_default_creator_id__user_id', $userIdToSave);
-        if ($userIdToPass) {
-            self::$_default_creator_id = $userIdToPass;
+        $user_id = (int) apply_filters('FHEE__EE_Multisite__get_default_creator_id__user_id', $user_id);
+        if ($user_id) {
+            self::$_default_creator_id = $user_id;
             return self::$_default_creator_id;
         } else {
             return null;

--- a/EE_Multisite.class.php
+++ b/EE_Multisite.class.php
@@ -258,16 +258,18 @@ class EE_Multisite extends EE_Addon
         }
         // find the earliest admin id for the current blog
         global $wpdb;
-        $offset = 0;
+        $blogId = get_current_blog_id();
         $role_to_check = apply_filters('FHEE__EE_Multisite__get_default_creator_id__role_to_check', 'administrator');
-        do {
-            $query = $wpdb->prepare(
-                "SELECT user_id from {$wpdb->usermeta} WHERE meta_key='primary_blog' AND meta_value=%s ORDER BY user_id ASC LIMIT %d, 1",
-                get_current_blog_id(),
-                $offset++
-            );
-            $user_id = $wpdb->get_var($query);
-        } while ($user_id && ! user_can($user_id, $role_to_check));
+        $query = $wpdb->prepare(
+            "SELECT u1.user_id FROM {$wpdb->usermeta} AS u1 "
+            . "INNER JOIN {$wpdb->usermeta} AS u2 ON u1.user_id = u2.user_id "
+            . "WHERE u1.meta_key='primary_blog' AND u1.meta_value=%s AND u2.meta_key=%s "
+            . "AND u2.meta_value LIKE %s ORDER BY user_id ASC LIMIT 1",
+            $blogId,
+            $wpdb->prefix . 'capabilities',
+            "%{$role_to_check}%"
+        );
+        $user_id = $wpdb->get_var($query);
         $user_id = (int) apply_filters('FHEE__EE_Multisite__get_default_creator_id__user_id', $user_id);
         if ($user_id) {
             self::$_default_creator_id = $user_id;

--- a/EE_Multisite.class.php
+++ b/EE_Multisite.class.php
@@ -112,11 +112,14 @@ class EE_Multisite extends EE_Addon
         foreach ($actions_that_could_change_mm as $action_name) {
             add_action($action_name, array('EE_Multisite', 'possible_maintenance_mode_change_detected'));
         }
-        // a very specific hook for when running the EE_DMS_Core_4_5_0
-        add_filter(
-            'FHEE__EEH_Activation__get_default_creator_id__pre_filtered_id',
-            array('EE_Multisite', 'filter_get_default_creator_id')
-        );
+        // a very specific hook for when running the EE_DMS_Core_4_5_0, use it only on the maintenance mode enabled.
+        $maintenanceEnabled = EE_Maintenance_Mode::instance()->level();
+        if ($maintenanceEnabled) {
+            add_filter(
+                'FHEE__EEH_Activation__get_default_creator_id__pre_filtered_id',
+                array('EE_Multisite', 'filter_get_default_creator_id')
+            );
+        }
         add_action(
             'AHEE__EE_System__initialize',
             array('EE_Multisite', 'mark_blog_as_up_to_date_if_no_migrations_needed')

--- a/EE_Multisite.class.php
+++ b/EE_Multisite.class.php
@@ -259,18 +259,23 @@ class EE_Multisite extends EE_Addon
         // find the earliest admin id for the current blog
         global $wpdb;
         $offset = 0;
+        $userIdToSave = null;
         $role_to_check = apply_filters('FHEE__EE_Multisite__get_default_creator_id__role_to_check', 'administrator');
         do {
             $query = $wpdb->prepare(
-                "SELECT user_id from {$wpdb->usermeta} WHERE meta_key='primary_blog' AND meta_value=%s ORDER BY user_id ASC LIMIT %d, 1",
+                "SELECT user_id from {$wpdb->usermeta} WHERE meta_key='primary_blog' "
+                . "AND meta_value=%s ORDER BY user_id ASC LIMIT %d, 1",
                 get_current_blog_id(),
                 $offset++
             );
             $user_id = $wpdb->get_var($query);
+            if ($user_id) {
+                $userIdToSave = $user_id;
+            }
         } while ($user_id && ! user_can($user_id, $role_to_check));
-        $user_id = (int) apply_filters('FHEE__EE_Multisite__get_default_creator_id__user_id', $user_id);
-        if ($user_id) {
-            self::$_default_creator_id = $user_id;
+        $userIdToPass = (int) apply_filters('FHEE__EE_Multisite__get_default_creator_id__user_id', $userIdToSave);
+        if ($userIdToPass) {
+            self::$_default_creator_id = $userIdToPass;
             return self::$_default_creator_id;
         } else {
             return null;


### PR DESCRIPTION
## Problem this Pull Request solves

This is a part of https://github.com/eventespresso/eventsmart.com-website/issues/793

As mentioned in [this comment](https://github.com/eventespresso/eventsmart.com-website/issues/793#issuecomment-716662206), `FHEE__EEH_Activation__get_default_creator_id__pre_filtered_id` filter added in this addon was a part of a DMS requirement, and I'm not sure it's really needed anymore as a permanent filter as it adds a few more redundant queries to the `usermeta` table on each sub site on a lot of requests.

This PR also fixes the `while` statement, where the `$user_id` that's passed back is usually a `null`.

## How has this been tested

Testing will be done on MENW and the notes will be provided in a PR created as a part of this plugin update. The PR will be listed here after this PR is reviewed.

