### PR TITLE
GitHub Actions | Use composite action for LAMP set up

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -11,95 +11,32 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ["7.3"] #, '7.4', '8.0', '8.1']
-    name: Lint with PHP ${{ matrix.php-versions }}
+        php-version: ["7.3"]
+    name: Lint with PHP ${{ matrix.php-version }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - name: Checkout and set up LAMP
+        uses: eventespresso/actions/packages/checkout-and-LAMP@main
         with:
-          php-version: ${{ matrix.php-versions }}
-
-      - name: Get composer cache directory
-        id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache composer dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composercache.outputs.dir }}
-          # Use composer-lock.json for key
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install dependencies
-        run: composer install
+          php-version: ${{ matrix.php-version }}
 
       - name: PHP Lint
         run: composer config-eventespressocs && composer run-script lint:skip-warnings
-        # Allow failure for PHP > 7.3
-        # continue-on-error: ${{ matrix.php-versions != '7.3' }}
 
   php-unit-tests:
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ubuntu-latest
     needs: what_has_changed
     # Run only if PHP files have changed
     if: ${{ needs.what_has_changed.outputs.php == 'true' }}
-    env:
-      EE_VERSION: master
-      PHPUNIT_VER: v7 # default
-      WP_VERSION: latest
-      WP_MULTISITE: 0
     strategy:
       matrix:
-        operating-system: [ubuntu-latest]
-        php-versions: ["5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
-    name: Unit Tests with PHP ${{ matrix.php-versions }}
+        php-version: ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
+    name: PHP ${{ matrix.php-version }} Test on ${{ matrix.operating-system }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set PHPUnit version
-        run: |
-          if [[ -n "${{ matrix.php-versions }}" ]]; then
-            case "${{ matrix.php-versions }}" in
-              7.0)
-                echo "Using PHPUnit 6"
-                echo "PHPUNIT_VER=v6" >> $GITHUB_ENV
-                ;;
-              5.6)
-                echo "Using PHPUnit 5"
-                echo "PHPUNIT_VER=5.7.22" >> $GITHUB_ENV
-                ;;
-            esac
-          fi
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - name: Checkout and set up LAMP
+        uses: eventespresso/actions/packages/checkout-and-LAMP@main
         with:
-          php-version: ${{ matrix.php-versions }}
-          tools: phpunit:${{ env.PHPUNIT_VER }}
-          extensions: mysql # needed for PHP < 7.1
-
-      - name: Start mysql service
-        run: sudo /etc/init.d/mysql start
-
-      - name: Get composer cache directory
-        id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache composer dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composercache.outputs.dir }}
-          # Use composer.lock for key.
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Check PHP Version
-        run: php -v
+          php-version: ${{ matrix.php-version }}
+          php-tools: phpunit:v7
 
       - name: Install WP Tests
         uses: eventespresso/actions/packages/install-wp-tests@main
@@ -116,11 +53,11 @@ jobs:
 
       - name: Run PHP Unit Tests
         run: phpunit --configuration tests/phpunit.xml
-        # Allow failure for nightly builds - PHP 8.0/8.1
-        continue-on-error: ${{ matrix.php-versions == '8.0' || matrix.php-versions == '8.1' }}
+        # Allow failure for PHP 8.x
+        continue-on-error: ${{ startsWith( matrix.php-version, '8.' ) }}
 
         # run multisite test only with 1 PHP version
-      - if: ${{ matrix.php-versions == '7.4' }}
+      - if: ${{ matrix.php-version == '7.4' }}
         name: Run PHP Unit Tests - WP Multisite
         env:
           WP_MULTISITE: 1
@@ -144,6 +81,6 @@ jobs:
           base: ${{ github.ref }}
           filters: |
             assets:
-              - 'admin/multisite/assets/**'
+              - 'assets/**'
             php:
               - '**/*.php'


### PR DESCRIPTION
This PR uses the extracted composite action to checkout the commit and set up LAMP stack to avoid unnecessary repetition.